### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/saj_modbus/manifest.json
+++ b/custom_components/saj_modbus/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "saj_modbus",
   "name": "SAJ Inverter Modbus",
+   "version": "0.1",
   "documentation": "https://github.com/wimb0/home-assistant-saj-modbus",
   "requirements": ["pymodbus==1.5.2"],
   "dependencies": [],


### PR DESCRIPTION
Home assistant requires manifest.json to have version information in it from 2021.3