### PR TITLE
Remove title (hassfest validation)

### DIFF
--- a/custom_components/saj_modbus/strings.json
+++ b/custom_components/saj_modbus/strings.json
@@ -1,6 +1,5 @@
 {
   "config": {
-    "title": "SAJ Inverter Modbus",
     "step": {
       "user": {
         "title": "Define your SAJ Inverter modbus-connection",

--- a/custom_components/saj_modbus/translations/en.json
+++ b/custom_components/saj_modbus/translations/en.json
@@ -1,6 +1,5 @@
 {
   "config": {
-    "title": "SAJ Inverter Modbus",
     "step": {
       "user": {
         "title": "Define your SAJ Inverter modbus-connection",

--- a/custom_components/saj_modbus/translations/nl.json
+++ b/custom_components/saj_modbus/translations/nl.json
@@ -1,6 +1,5 @@
 {
   "config": {
-    "title": "SAJ Inverter Modbus",
     "step": {
       "user": {
         "title": "Definieer uw SAJ Inverter modbus-verbinding",


### PR DESCRIPTION
Fixes hassfest validation:
[TRANSLATIONS] config.title key has been moved out of config and into the root of strings.json. Starting Home Assistant 0.109 you only need to define this key in the root if the title needs to be different than the name of your integration in the manifest.