### PR TITLE
Update pymodbus version in manifest.json

### DIFF
--- a/custom_components/saj_modbus/manifest.json
+++ b/custom_components/saj_modbus/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/wimb0/home-assistant-saj-modbus/issues",
   "requirements": [
-    "pymodbus==2.3.0"
+    "pymodbus==3.3.1"
   ],
   "version": "1.7.0"
 }


### PR DESCRIPTION
Bumped pymodbus version to allow interoperability with home assistant version and the modbus integration.

See: https://github.com/home-assistant/core/issues/86882, this was also updated in https://github.com/binsentsu/home-assistant-solaredge-modbus/blob/master/custom_components/solaredge_modbus/manifest.json#L5