### PR TITLE
Update pymodbus version in manifest.json

### DIFF
--- a/custom_components/saj_modbus/hub.py
+++ b/custom_components/saj_modbus/hub.py
@@ -65,7 +65,7 @@ class SAJModbusHub(DataUpdateCoordinator[dict]):
         """Read holding registers."""
         with self._lock:
             kwargs = {"unit": unit} if unit else {}
-            return self._client.read_holding_registers(address, count, **kwargs)
+            return self._client.read_holding_registers(address=address, count=count, **kwargs)
 
     async def _async_update_data(self) -> dict:
         realtime_data = {}

--- a/custom_components/saj_modbus/hub.py
+++ b/custom_components/saj_modbus/hub.py
@@ -64,8 +64,7 @@ class SAJModbusHub(DataUpdateCoordinator[dict]):
     ) -> ReadHoldingRegistersResponse:
         """Read holding registers."""
         with self._lock:
-            kwargs = {"unit": unit} if unit else {}
-            return self._client.read_holding_registers(address=address, count=count, **kwargs)
+            return self._client.read_holding_registers(address=address, count=count, slave=unit)
 
     async def _async_update_data(self) -> dict:
         realtime_data = {}

--- a/custom_components/saj_modbus/hub.py
+++ b/custom_components/saj_modbus/hub.py
@@ -7,7 +7,7 @@ import logging
 import threading
 from datetime import timedelta
 from homeassistant.core import CALLBACK_TYPE, callback
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 from pymodbus.constants import Endian
 from pymodbus.exceptions import ConnectionException
 from pymodbus.payload import BinaryPayloadDecoder

--- a/custom_components/saj_modbus/manifest.json
+++ b/custom_components/saj_modbus/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/wimb0/home-assistant-saj-modbus/issues",
   "requirements": [
-    "pymodbus==2.3.0"
+    "pymodbus==3.3.1"
   ],
   "version": "1.7.0"
 }


### PR DESCRIPTION
Bumped pymodbus version to allow interoperability with home assistant version and the modbus integration.

See: https://github.com/home-assistant/core/issues/86882, this was also updated in https://github.com/binsentsu/home-assistant-solaredge-modbus/blob/master/custom_components/solaredge_modbus/manifest.json#L5