### PR TITLE
Do not set the output power limit if the related entity is disabled

### DIFF
--- a/custom_components/saj_modbus/const.py
+++ b/custom_components/saj_modbus/const.py
@@ -28,7 +28,7 @@ ATTR_MANUFACTURER = "SAJ Electric"
 
 @dataclass
 class SajModbusNumberEntityDescription(NumberEntityDescription):
-    """A class that describes Zoonneplan sensor entities."""
+    """A class that describes SAJ number entities."""
 
 NUMBER_TYPES: dict[str, list[SajModbusNumberEntityDescription]] = {
     "LimitPower": SajModbusNumberEntityDescription(
@@ -42,7 +42,7 @@ NUMBER_TYPES: dict[str, list[SajModbusNumberEntityDescription]] = {
 
 @dataclass
 class SajModbusSensorEntityDescription(SensorEntityDescription):
-    """A class that describes SAJ number entities."""
+    """A class that describes SAJ sensor entities."""
 
 
 SENSOR_TYPES: dict[str, list[SajModbusSensorEntityDescription]] = {


### PR DESCRIPTION
As per the discussion in #81, it may not be desirable to always set the output power limit on start and stop.

With this PR, we only actually set the limit on the inverter to 100% if the related `number` entity exists and is not disabled.
Users that don't want the integration to change their configured limit should make sure the inverter is unreachable when they upgrade and disable the `Limit Power` entity before the inverter can be reached again.

I also included a change to some docstrings that I messed up in the previous PR. If required I can make this a separate PR.