### PR TITLE
Add set_datetime service

### DIFF
--- a/custom_components/saj_modbus/__init__.py
+++ b/custom_components/saj_modbus/__init__.py
@@ -14,6 +14,7 @@ from .const import (
     DOMAIN,
 )
 from .hub import SAJModbusHub
+from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,6 +61,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, component)
         )
+
+    async_setup_services(hass)
+
     return True
 
 

--- a/custom_components/saj_modbus/services.py
+++ b/custom_components/saj_modbus/services.py
@@ -1,0 +1,72 @@
+"""SAJ Modbus services."""
+
+from collections.abc import Mapping
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.const import ATTR_DEVICE_ID
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers import (
+    device_registry as dr,
+    config_validation as cv
+)
+
+from .const import DOMAIN as SAJ_DOMAIN
+
+ATTR_DATETIME = "datetime"
+
+SERVICE_SET_DATE_TIME = "set_datetime"
+
+SERVICE_SET_DATE_TIME_SCHEMA = vol.All(
+    vol.Schema({
+        vol.Required(ATTR_DEVICE_ID): str,
+        vol.Optional(ATTR_DATETIME): cv.datetime,
+    })
+)
+
+SUPPORTED_SERVICES = (SERVICE_SET_DATE_TIME,)
+
+SERVICE_TO_SCHEMA = {
+    SERVICE_SET_DATE_TIME: SERVICE_SET_DATE_TIME_SCHEMA,
+}
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up services for SAJ Modbus integration."""
+
+    services = {
+        SERVICE_SET_DATE_TIME: async_set_date_time,
+    }
+
+    async def async_call_service(service_call: ServiceCall) -> None:
+        """Call correct SAJ Modbus service."""
+        await services[service_call.service](hass, service_call.data)
+
+    for service in SUPPORTED_SERVICES:
+        hass.services.async_register(
+            SAJ_DOMAIN,
+            service,
+            async_call_service,
+            schema=SERVICE_TO_SCHEMA.get(service),
+        )
+
+
+@callback
+def async_unload_services(hass: HomeAssistant) -> None:
+    """Unload SAJ Modbus services."""
+    for service in SUPPORTED_SERVICES:
+        hass.services.async_remove(SAJ_DOMAIN, service)
+
+
+async def async_set_date_time(hass: HomeAssistant, data: Mapping[str, Any]) -> None:
+    """Set the date and time on the inverter."""
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get(data[ATTR_DEVICE_ID])
+
+    hub = hass.data[SAJ_DOMAIN][device_entry.name]["hub"]
+    await hass.async_add_executor_job(
+        hub.set_date_and_time,
+        data.get(ATTR_DATETIME, None)
+    )

--- a/custom_components/saj_modbus/services.yaml
+++ b/custom_components/saj_modbus/services.yaml
@@ -1,0 +1,12 @@
+set_datetime:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: saj_modbus
+    datetime:
+      required: false
+      example: "2024-01-23T12:34:56"
+      selector:
+        datetime:

--- a/custom_components/saj_modbus/strings.json
+++ b/custom_components/saj_modbus/strings.json
@@ -17,5 +17,21 @@
     "abort": {
       "already_configured": "Device is already configured"
     }
+  },
+  "services": {
+    "set_datetime": {
+      "name": "Set date and time",
+      "description": "Sets the date and time on the inverter.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The inverter on which the date and time will be set."
+        },
+        "datetime": {
+          "name": "Date and time",
+          "description": "The date and time to be set on the inverter."
+        }
+      }
+    }
   }
 }

--- a/custom_components/saj_modbus/translations/en.json
+++ b/custom_components/saj_modbus/translations/en.json
@@ -17,5 +17,21 @@
     "abort": {
       "already_configured": "Device is already configured"
     }
+  },
+  "services": {
+    "set_datetime": {
+      "name": "Set date and time",
+      "description": "Sets the date and time on the inverter.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The inverter on which the date and time will be set."
+        },
+        "datetime": {
+          "name": "Date and time",
+          "description": "The date and time to be set on the inverter."
+        }
+      }
+    }
   }
 }

--- a/custom_components/saj_modbus/translations/nl.json
+++ b/custom_components/saj_modbus/translations/nl.json
@@ -17,5 +17,21 @@
     "abort": {
       "already_configured": "Apparaat is al geconfigureerd"
     }
+  },
+    "services": {
+    "set_datetime": {
+      "name": "Stel datum en tijd in",
+      "description": "Stelt de datum en tijd van de omvormer in.",
+      "fields": {
+        "device_id": {
+          "name": "Apparaat",
+          "description": "De omvormer waarop de datum en tijd ingesteld zullen worden."
+        },
+        "datetime": {
+          "name": "Datum en tijd",
+          "description": "De datum en tijd die op de omvormer ingesteld zullen worden."
+        }
+      }
+    }
   }
 }

--- a/custom_components/saj_modbus/translations/nl.json
+++ b/custom_components/saj_modbus/translations/nl.json
@@ -18,7 +18,7 @@
       "already_configured": "Apparaat is al geconfigureerd"
     }
   },
-    "services": {
+  "services": {
     "set_datetime": {
       "name": "Stel datum en tijd in",
       "description": "Stelt de datum en tijd van de omvormer in.",


### PR DESCRIPTION
Add a service to set the date and time on the inverter.

While installing the Modbus TCP module on my inverter I decided to remove the Zonneplan 4G module at the same time, only to realize later that the 4G module probably kept the time on the inverter in sync as well.
With this PR we can use the service `saj_modbus.set_datetime` to set the date and time on the inverter. It will set the current date and time by default, but there's also an option to provide your own values (this should only be necessary when your inverter is located in a different timezone for some reason).

The implementation does not update the time automatically. Users should create their own automation to keep the time synchronized.