### PR TITLE
Report only reliable values for counters

### DIFF
--- a/custom_components/saj_modbus/const.py
+++ b/custom_components/saj_modbus/const.py
@@ -44,6 +44,56 @@ NUMBER_TYPES: dict[str, list[SajModbusNumberEntityDescription]] = {
 class SajModbusSensorEntityDescription(SensorEntityDescription):
     """A class that describes SAJ number entities."""
 
+COUNTER_SENSOR_TYPES: dict[str, list[SajModbusSensorEntityDescription]] = {
+    "TodayEnergy": SajModbusSensorEntityDescription(
+        name="Power generation on current day",
+        key="todayenergy",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        icon="mdi:solar-power",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    "MonthEnergy": SajModbusSensorEntityDescription(
+        name="Power generation in current month",
+        key="monthenergy",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        icon="mdi:solar-power",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_registry_enabled_default=False,
+    ),
+    "YearEnergy": SajModbusSensorEntityDescription(
+        name="Power generation in current year",
+        key="yearenergy",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        icon="mdi:solar-power",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_registry_enabled_default=False,
+    ),
+    "TotalEnergy": SajModbusSensorEntityDescription(
+        name="Total power generation",
+        key="totalenergy",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        icon="mdi:solar-power",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    "TodayHour": SajModbusSensorEntityDescription(
+        name="Daily working hours",
+        key="todayhour",
+        native_unit_of_measurement=UnitOfTime.HOURS,
+        icon="mdi:progress-clock",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    "TotalHour": SajModbusSensorEntityDescription(
+        name="Total working hours",
+        key="totalhour",
+        native_unit_of_measurement=UnitOfTime.HOURS,
+        icon="mdi:progress-clock",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+}
 
 SENSOR_TYPES: dict[str, list[SajModbusSensorEntityDescription]] = {
     "DevType": SajModbusSensorEntityDescription(
@@ -421,54 +471,6 @@ SENSOR_TYPES: dict[str, list[SajModbusSensorEntityDescription]] = {
         native_unit_of_measurement="kΩ",
         icon="mdi:omega",
         entity_registry_enabled_default=False,
-    ),
-    "TodayEnergy": SajModbusSensorEntityDescription(
-        name="Power generation on current day",
-        key="todayenergy",
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        icon="mdi:solar-power",
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-    ),
-    "MonthEnergy": SajModbusSensorEntityDescription(
-        name="Power generation in current month",
-        key="monthenergy",
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        icon="mdi:solar-power",
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        entity_registry_enabled_default=False,
-    ),
-    "YearEnergy": SajModbusSensorEntityDescription(
-        name="Power generation in current year",
-        key="yearenergy",
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        icon="mdi:solar-power",
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        entity_registry_enabled_default=False,
-    ),
-    "TotalEnergy": SajModbusSensorEntityDescription(
-        name="Total power generation",
-        key="totalenergy",
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        icon="mdi:solar-power",
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-    ),
-    "TodayHour": SajModbusSensorEntityDescription(
-        name="Daily working hours",
-        key="todayhour",
-        native_unit_of_measurement=UnitOfTime.HOURS,
-        icon="mdi:progress-clock",
-        state_class=SensorStateClass.TOTAL_INCREASING,
-    ),
-    "TotalHour": SajModbusSensorEntityDescription(
-        name="Total working hours",
-        key="totalhour",
-        native_unit_of_measurement=UnitOfTime.HOURS,
-        icon="mdi:progress-clock",
-        state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     "ErrorCount": SajModbusSensorEntityDescription(
         name="Error count",


### PR DESCRIPTION
## The Problem
During hours of low light, the values reported by the inverter are not always reliable. The reported values sometimes drop to 0 or some seemingly random intermediate value. Here's a screenshot of one evening where I observed the problem:
![Screenshot_2024-04-07_22-28-13](https://github.com/wimb0/home-assistant-saj-modbus/assets/4738593/4a6616dd-6708-427f-b44c-7b9107b964bb)
For most entities this isn't an issue, but for the counter sensors that may be used e.g. in the Energy dashboard it messes up the graphs and I have to correct the statistics manually.
As you can see on the screenshot, the incorrect values are only reported when the working mode is `0` or `Unknown`. When the working mode is `1` or `2` (not shown in the screenshot) the values are reliable.

## The Solution
In this PR we add a `SajCounterSensor` subclass of the currently used `SajSensor` in which we only report values if the working mode is either `1` (`Waiting`) or `2` (`Normal`). We then use this subclass for all counter-type sensors. This way we only report reliable values and the Energy dashboard no longer gets messed up.
