### PR TITLE
Update Limit Power entity to match actual device behavior

### DIFF
--- a/custom_components/saj_modbus/const.py
+++ b/custom_components/saj_modbus/const.py
@@ -33,6 +33,8 @@ class SajModbusNumberEntityDescription(NumberEntityDescription):
 NUMBER_TYPES: dict[str, list[SajModbusNumberEntityDescription]] = {
     "LimitPower": SajModbusNumberEntityDescription(
         name="Limit Power",
+        native_max_value=110,
+        native_min_value=0,
         key="limitpower",
         icon="mdi:solar-power",
         native_unit_of_measurement="%",

--- a/custom_components/saj_modbus/number.py
+++ b/custom_components/saj_modbus/number.py
@@ -56,23 +56,19 @@ class SajNumber(CoordinatorEntity, NumberEntity):
         """Initialize the sensor."""
         self._platform_name = platform_name
         self._attr_device_info = device_info
+        self._attr_unique_id = f"{platform_name}_{description.key}"
         self.entity_description: SajModbusNumberEntityDescription = description
 
         super().__init__(coordinator=hub)
 
     @property
-    def name(self):
-        """Return the name."""
-        return f"{self._platform_name} {self.entity_description.name}"
+    def available(self) -> bool:
+        return self.native_value is not None
 
     @property
-    def unique_id(self) -> Optional[str]:
-        return f"{self._platform_name}_{self.entity_description.key}"
-
-    @property
-    def native_value(self):
+    def native_value(self) -> Optional[int]:
         """Return the state of the number entity."""
-        return getattr(self.coordinator, self.entity_description.key, None)
+        return self.coordinator.data.get(self.entity_description.key, None)
 
     def set_native_value(self, value: float) -> None:
         """Update the current value."""


### PR DESCRIPTION
After running some tests it seems that the inverter resets its output limit to `110%` every time `mpvmode` changes to `2` (`Normal`). This PR is meant to reflect that behavior in the following ways:
* When `mpvmode` is not `2`, disable the `Limit Power` number entity
* When `mpvmode` changes to `2`, set the `Limit Power` number entity to `110%` (internally only, no data is sent to the inverter)
* While `mpvmode` remains `2`, track the power limit internally

One potential issue with this method is that the `Limit Power` entity may de-synchronize from the actual limit. This will happen in case of a re-load of the integration after setting a lower limit while `mpvmode` remains `2` in the inverter.
A possible solution to this would be to actively set the limit to `110%` when `mpvmode` changes to `2`. If this is deemed desirable then I will update the PR. Otherwise users can do this with a simple automation.

fixes #86 